### PR TITLE
Implement an action endpoint route

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -58,6 +58,7 @@ def index():
                 "get_item": "GET /orders/{id}/items/{item_id}",
                 "update_item": "PUT /orders/{id}/items/{item_id}",
                 "delete_item": "DELETE /orders/{id}/items/{item_id}",
+                "order_action": "POST /orders/{id}/actions/{action_name}",
             },
         ),
         status.HTTP_200_OK,
@@ -333,6 +334,42 @@ def update_order_item(order_id, item_id):
 
     app.logger.info("Item %s in order %s updated.", item_id, order_id)
     return jsonify(item.serialize()), status.HTTP_200_OK
+
+
+######################################################################
+# TRIGGER AN ACTION ON AN ORDER
+######################################################################
+ACTION_MAP = {
+    "pay": "Paid",
+    "ship": "Shipped",
+    "cancel": "Cancelled",
+}
+
+
+@app.route("/orders/<int:order_id>/actions/<action_name>", methods=["POST"])
+def order_action(order_id, action_name):
+    """Trigger a named action on an Order"""
+    app.logger.info("Request to trigger action '%s' on order [%s]", action_name, order_id)
+
+    if action_name not in ACTION_MAP:
+        abort(status.HTTP_404_NOT_FOUND, f"Action '{action_name}' not found.")
+
+    order = Order.find(order_id)
+    if not order:
+        abort(status.HTTP_404_NOT_FOUND, f"Order with id '{order_id}' was not found.")
+
+    target_status = ACTION_MAP[action_name]
+    allowed = VALID_TRANSITIONS.get(order.status, [])
+    if target_status not in allowed:
+        abort(
+            status.HTTP_409_CONFLICT,
+            f"Cannot perform '{action_name}' on order with status '{order.status}'.",
+        )
+
+    order.status = target_status
+    order.update()
+    app.logger.info("Order [%s] transitioned to '%s' via action '%s'.", order_id, target_status, action_name)
+    return jsonify(order.serialize()), status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -547,6 +547,53 @@ class OrderService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     ######################################################################
+    #  A C T I O N   E N D P O I N T   T E S T S
+    ######################################################################
+
+    def test_action_pay_pending_order(self):
+        """It should transition a Pending order to Paid via the pay action"""
+        order = OrderFactory(status="Pending")
+        order.create()
+        response = self.client.post(f"{BASE_URL}/{order.id}/actions/pay")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.get_json()["status"], "Paid")
+
+    def test_action_ship_paid_order(self):
+        """It should transition a Paid order to Shipped via the ship action"""
+        order = OrderFactory(status="Paid")
+        order.create()
+        response = self.client.post(f"{BASE_URL}/{order.id}/actions/ship")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.get_json()["status"], "Shipped")
+
+    def test_action_cancel_pending_order(self):
+        """It should transition a Pending order to Cancelled via the cancel action"""
+        order = OrderFactory(status="Pending")
+        order.create()
+        response = self.client.post(f"{BASE_URL}/{order.id}/actions/cancel")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.get_json()["status"], "Cancelled")
+
+    def test_action_undefined_returns_404(self):
+        """It should return 404 for an undefined action name"""
+        order = OrderFactory(status="Pending")
+        order.create()
+        response = self.client.post(f"{BASE_URL}/{order.id}/actions/refund")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_action_order_not_found(self):
+        """It should return 404 when the order does not exist"""
+        response = self.client.post(f"{BASE_URL}/0/actions/pay")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_action_invalid_transition(self):
+        """It should return 409 when the action is not valid for the current status"""
+        order = OrderFactory(status="Shipped")
+        order.create()
+        response = self.client.post(f"{BASE_URL}/{order.id}/actions/pay")
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    ######################################################################
     #  S T A T U S   W O R K F L O W   T E S T S
     ######################################################################
 


### PR DESCRIPTION
## Summary
- Adds `POST /orders/{id}/actions/{action_name}` endpoint to trigger state-transition actions (`pay`, `ship`, `cancel`) on an order.
- Returns 200 on success, 404 for undefined actions or missing orders, 409 when the transition is invalid for the current status.
- Adds 6 unit tests covering success, undefined action, order-not-found, and invalid-transition paths.

## Test plan
- [ ] `pytest tests/test_routes.py -k action` passes
- [ ] `POST /orders/{id}/actions/pay` on a Pending order returns 200 with status `Paid`
- [ ] `POST /orders/{id}/actions/refund` returns 404
- [ ] `POST /orders/{id}/actions/pay` on a Shipped order returns 409