### PR TITLE
Add a minimal Tekton pipeline structure

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: orders-cd-pipeline
+spec:
+  description: |
+    Minimal Tekton pipeline definition for the Orders service.
+    Individual pipeline tasks will be added in separate stories.
+
+  params:
+    - name: repo-url
+      type: string
+      description: GitHub repository URL for the Orders service
+    - name: revision
+      type: string
+      description: Git revision to build
+      default: main
+    - name: image-name
+      type: string
+      description: Container image name for the Orders service
+    - name: base-url
+      type: string
+      description: OpenShift route URL used by BDD tests
+
+  workspaces:
+    - name: shared-workspace
+
+  tasks: []

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -1,0 +1,8 @@
+# Tekton Task definitions for the Orders CD pipeline.
+# Planned tasks:
+# - clone-repo
+# - lint
+# - test
+# - build-image
+# - deploy
+# - bdd-tests

--- a/.tekton/workspace.yaml
+++ b/.tekton/workspace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pipeline-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
This PR adds the minimal Tekton structure for the CD pipeline.

Changes:
- Added .tekton/ folder
- Added pipeline.yaml with basic pipeline metadata, parameters, and shared workspace
- Added workspace.yaml with a PersistentVolumeClaim for the Tekton shared workspace
- Added tasks.yaml for future Task definitions