### PR TITLE
Deploy to Openshift Task and Run BDD Tests Against Deployment Task

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -3,24 +3,16 @@ kind: Pipeline
 metadata:
   name: orders-cd-pipeline
 spec:
-  description: |
-    Minimal Tekton pipeline definition for the Orders service.
-    Individual pipeline tasks will be added in separate stories.
-
   params:
     - name: repo-url
       type: string
-      description: GitHub repository URL for the Orders service
     - name: revision
       type: string
-      description: Git revision to build
       default: master
     - name: image-name
       type: string
-      description: Container image name for the Orders service
     - name: base-url
       type: string
-      description: OpenShift route URL used by BDD tests
 
   workspaces:
     - name: shared-workspace
@@ -48,3 +40,25 @@ spec:
       workspaces:
         - name: source
           workspace: shared-workspace
+    - name: deploy
+      taskRef:
+        name: deploy
+      runAfter:
+        - build
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: IMAGE
+          value: $(params.image-name)
+    - name: bdd-tests
+      taskRef:
+        name: bdd-tests
+      runAfter:
+        - deploy
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: BASE_URL
+          value: $(params.base-url)

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -1,23 +1,12 @@
-# Tekton Task definitions for the Orders CD pipeline.
-# Planned tasks:
-# - clone-repo
-# - lint
-# - test
-# - build-image
-# - deploy
-# - bdd-tests
 ---
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: lint
 spec:
-  description: >-
-    Run flake8 and pylint against the cloned source. Any lint failure exits
-    non-zero so the pipeline stops before build and deploy.
+  description: Run flake8 and pylint on the cloned source.
   workspaces:
     - name: source
-      description: The workspace containing the cloned source code.
   steps:
     - name: lint
       image: docker.io/python:3.12-slim
@@ -28,12 +17,86 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        echo "***** Installing dependencies *****"
         python -m pip install --upgrade pip pipenv
         pipenv install --system --dev
-        echo "***** Running flake8 (syntax errors) *****"
         flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics
-        echo "***** Running flake8 (style) *****"
         flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistics
-        echo "***** Running pylint *****"
         pylint service tests --max-line-length=127
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: deploy
+spec:
+  description: Apply k8s manifests, swap in the new image, wait for rollout.
+  workspaces:
+    - name: source
+  params:
+    - name: IMAGE
+      type: string
+    - name: DEPLOYMENT
+      type: string
+      default: orders
+    - name: ROLLOUT_TIMEOUT
+      type: string
+      default: 5m
+  steps:
+    - name: apply
+      image: quay.io/openshift/origin-cli:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        oc apply -f k8s/deployment.yaml -f k8s/service.yaml -f k8s/ingress.yaml
+    - name: set-image
+      image: quay.io/openshift/origin-cli:latest
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        oc set image deployment/$(params.DEPLOYMENT) $(params.DEPLOYMENT)=$(params.IMAGE)
+    - name: rollout
+      image: quay.io/openshift/origin-cli:latest
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        oc rollout status deployment/$(params.DEPLOYMENT) --timeout=$(params.ROLLOUT_TIMEOUT)
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: bdd-tests
+spec:
+  description: Run Behave against the deployed service.
+  workspaces:
+    - name: source
+  params:
+    - name: BASE_URL
+      type: string
+    - name: WAIT_ATTEMPTS
+      type: string
+      default: "30"
+    - name: WAIT_INTERVAL
+      type: string
+      default: "5"
+  steps:
+    - name: behave
+      image: docker.io/python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: BASE_URL
+          value: $(params.BASE_URL)
+        - name: DRIVER
+          value: chrome
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        apt-get update
+        apt-get install -y --no-install-recommends chromium chromium-driver curl
+        rm -rf /var/lib/apt/lists/*
+        python -m pip install --upgrade pip pipenv
+        pipenv install --system --dev
+        for attempt in $(seq 1 $(params.WAIT_ATTEMPTS)); do
+          curl --silent --fail --max-time 5 "${BASE_URL}" >/dev/null 2>&1 && break
+          sleep $(params.WAIT_INTERVAL)
+        done
+        behave


### PR DESCRIPTION
Adds the deploy and bdd-tests Tekton tasks and wires them into the pipeline DAG.

- `deploy` (custom Task, openshift CLI image): applies k8s manifests, sets the deployment image to the build output, waits for rollout. Runs after `build`.
- `bdd-tests` (custom Task, python:3.12-slim): installs Chromium and project deps, polls `BASE_URL` until reachable, runs `behave`. `BASE_URL` exposed as an env var. Runs after `deploy`.

Closes #69
Closes #67