### PR TITLE
Add OpenShift Route for orders service

### DIFF
--- a/k8s/route.yaml
+++ b/k8s/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: orders
+  labels:
+    app: orders
+spec:
+  to:
+    kind: Service
+    name: orders
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge


### PR DESCRIPTION
Adds `k8s/route.yaml` exposing the `orders` Service over HTTPS via TLS edge termination.

Applied manually with `oc apply -f k8s/route.yaml`. The resulting hostname is the `base-url` parameter for the PipelineRun and the URL submitted as the final deliverable.