### PR TITLE
Increase storage request for PersistentVolumeClaim to 1Gi

### DIFF
--- a/.tekton/workspace.yaml
+++ b/.tekton/workspace.yaml
@@ -7,5 +7,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Mi
+      storage: 1Gi
   volumeMode: Filesystem


### PR DESCRIPTION
## Summary
- Updated the Tekton pipeline workspace PVC storage request from 500Mi to 1Gi.
